### PR TITLE
Updated Python 2.7 to 3.5, fixed Filter methods, CircleCI to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+workflows:
+  run_tests:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              python_version: ["2.7", "3.5"]
+
+jobs:
+  test:
+    parameters:
+      python_version:
+        type: string
+        default: "3.5"
+    docker:
+      - image: python:<< parameters.python_version >>
+    working_directory: ~/flow-control-xblock
+    steps:
+      - checkout
+      - run :
+          name: Install requirements
+          command: |
+            pip install tox
+            apt install git
+      - run:
+          name: Run tox tests
+          command: tox -e ${python_version//./}
+    environment:
+      - python_version: py<< parameters.python_version >>

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - tox

--- a/flow_control/flow.py
+++ b/flow_control/flow.py
@@ -225,13 +225,13 @@ class FlowCheckPointXblock(StudioEditableXBlockMixin, XBlock):
         if self.problem_id and self.condition == 'single_problem':
             # now split problem id by spaces or commas
             problems = re.split('\s*,*|\s*,\s*', self.problem_id)
-            problems = filter(None, problems)
+            problems = list(filter(None, problems))
             problems = problems[:1]
 
         if self.list_of_problems and self.condition == 'average_problems':
             # now split list of problems id by spaces or commas
             problems = re.split('\s*,*|\s*,\s*', self.list_of_problems)
-            problems = filter(None, problems)
+            problems = list(filter(None, problems))
 
         if problems:
             condition_reached = self.condition_on_problem_list(problems)
@@ -392,7 +392,7 @@ class FlowCheckPointXblock(StudioEditableXBlockMixin, XBlock):
         usages_keys = map(_get_usage_key, problems)
         scores_client.fetch_scores(usages_keys)
         scores = map(scores_client.get, usages_keys)
-        scores = filter(None, scores)
+        scores = list(filter(None, scores))
 
         problems_to_answer = [score.total for score in scores]
         if self.operator in self.SPECIAL_COMPARISON_DISPATCHER.keys():

--- a/flow_control/requirements/base.txt
+++ b/flow_control/requirements/base.txt
@@ -1,4 +1,4 @@
 # Base requirements
-git+https://github.com/edx/XBlock.git@xblock-0.4.10#egg=XBlock==0.4.10
-git+https://github.com/edx/xblock-utils@v1.0.2#egg=xblock-utils==1.0.2
-git+https://github.com/edx/opaque-keys@0.3.1#egg=opaque-keys==0.3.1
+git+https://github.com/edx/XBlock.git@xblock-1.2.4#egg=XBlock==1.2.4
+git+https://github.com/edx/xblock-utils@v1.2.3#egg=xblock-utils==1.2.3
+git+https://github.com/edx/opaque-keys@2.1.0#egg=opaque-keys==2.1.0

--- a/flow_control/requirements/test.txt
+++ b/flow_control/requirements/test.txt
@@ -7,7 +7,9 @@ pyyaml==3.11
 mako==1.0.4
 mock
 ddt==1.2.0
--e git://github.com/edx/xblock-sdk.git@v0.1.2#egg=xblock-sdk==v0.1.2
--e git://github.com/nosedjango/nosedjango.git@ed7d7f9aa969252ff799ec159f828eaa8c1cbc5a#egg=nosedjango-dev
+django-nose==1.4.6
+
+
+-e git://github.com/edx/xblock-sdk.git@v0.1.8#egg=xblock-sdk==v0.1.8
 # mock project for couserware.model_data
 -e git://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # testing with tox
 [tox]
-envlist = py27
+envlist = py27,py35
 
 [testenv]
 deps = -rflow_control/requirements/test.txt


### PR DESCRIPTION
Updated Python 2.7 to 3.5, fixed Filter methods, CircleCI to 2.1

**Background**: 
After merging the PR by @Squirrel18, I proceeded with upgrading Flow Control to work with Python 3.5, as edx-platform Junyper uses this version of Python.

It's worth noting that Flow Control depends on XBlock and other edx packages.

Also, [CircleCI no longer uses a circle.yml file](https://circleci.com/docs/2.0/hello-world/), but instead now asks for a .circleci directory with all of its configuration files inside.

**Context**:  
From the failing tests, it was clear that there were conflicts between the edx packages. We updated the edx-based packages to their current versions. Specifically:

- Xblock (0.4.10 -> 1.2.4)
- Xblock-utils (1.0.2 -> 1.2.3)
- Opaque-keys (0.3.1 -> 2.1.0)
- Xblock-sdk (0.1.2 -> 0.1.8)

We also added `django-nose==1.4.6` (current version) from pip rather than git to tox's environment requirements

**Adding testing support for Python 3.5**:
An error with the `filter` method surfaced, wherein [Python 2.7](https://docs.python.org/2/library/functions.html#filter), the method returns a `list` and in [Python 3.5](https://docs.python.org/3.5/library/functions.html#filter) it returns an `iterator` object.

We simply use the `list` method to transform the `iterator` and the tests pass.

_Before:_
`filter(None, problems)`

_After:_
`list(filter(None, problems))`

**Upgrading to CircleCI 2.1:**
We implemented the new "matrix" statement to run parallel tests. We also added a little hack to use the correct Docker container and pass the correct environment parameter to tox.

```
# .circleci/config.yml

matrix:
  parameters:
  python_version: ["2.7", "3.5"]
...
docker:
  - image: python:<< parameters.python_version >>-alpine
steps:
  - run: tox -e ${python_version//./}
environment:
  - python_version: py<< parameters.python_version >> 
```

@felipemontoya
@jfavellar90
@morenol  