### PR TITLE
Upgrade CircleCI to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.1
+
+workflows:
+  run_tests:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              python_version: ["2.7"]
+
+jobs:
+  test:
+    parameters:
+      python_version:
+        type: string
+        default: "2.7"
+    docker:
+      - image: python:<< parameters.python_version >>
+    working_directory: ~/flow-control-xblock
+    steps:
+      - checkout
+      - run :
+          name: Install requirements
+          command: |
+            pip install tox
+            apt install git
+      - run:
+          name: Run tox tests
+          command: tox -e ${python_version//./}
+    environment:
+      - python_version: py<< parameters.python_version >>


### PR DESCRIPTION
**Background**:
[CircleCI no longer uses a circle.yml file](https://circleci.com/docs/2.0/hello-world/), but instead now asks for a .circleci directory with all of its configuration files inside.

**Context**:
We built the config file so it's easy to add new Python version testing using tox and taking advantage of the new matrix testing function in CircleCI 2.1.

```
workflows:

  run_tests:
    jobs:
      - test:
          matrix:
            parameters:
              python_version: ["2.7"]

```
