### PR TITLE
Added virtualenvironment to PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,14 +53,22 @@ jobs:
             echo -e "username = $PYPI_USERNAME" >> ~/.pypirc
             echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
       - run:
+          name: Prepare venv for distribution
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install twine
+      - run:
           name: Create package
           command: |
             python setup.py sdist bdist_wheel
       - run:
           name: Check package
           command: |
+            source venv/bin/activate
             twine check dist/*
       - run:
           name: Upload to pypi
           command: |
+            source venv/bin/activate
             twine upload dist/*


### PR DESCRIPTION
## Added virtualenvironment to PyPI

Added this step to ``pypi`` job for CircleCI
```

name: Prepare venv for distribution
  command: |
  virtualenv venv
  source venv/bin/activate
  pip install twine
```

## Reviewers
@morenol 