### PR TITLE
Juniper compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-/xblock_flow_control.egg-info/
+/flow_control_xblock.egg-info/
 *.coverage
 .tox/
 build/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include requirements/base.in
 include requirements/test.in
+recursive-include flow_control/static *

--- a/flow_control/flow.py
+++ b/flow_control/flow.py
@@ -10,7 +10,7 @@ from xblock.fragment import Fragment
 from xblock.fields import Scope, Integer, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
-from courseware.model_data import ScoresClient
+from lms.djangoapps.courseware.model_data import ScoresClient
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys import InvalidKeyError
 


### PR DESCRIPTION
Hi! I noticed that you already migrated this xblock to Python 3.5, so I tried to use it with Tutor. I was happy to discover that I only had to make a few changes, which I submit here.

I did not manage to get this xblock to work with Juniper, yet, but I'm confident that these few changes make sense and should be merged anyway.

# Reviewers

- [ ] who is the person reviewing this changes?
- [ ] perhaps more than one?

# After approval

Keep in mind that after the change have been approved we might still need to do somethings.

- [ ] Squash
- [ ] Bumpversion (major/minor/patch)
