### PR TITLE
Changed nosedjango tests to pytest-django

### DIFF
--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -2,13 +2,12 @@
 Unit tests for flow-control
 """
 
+import ddt
 import unittest
 
-import ddt
 from mock import MagicMock, patch
 # from xblock.core import XBlock
 from xblock.field_data import DictFieldData
-
 from flow_control.flow import FlowCheckPointXblock
 from flow_control.flow import (_actions_generator, _conditions_generator,
                                _operators_generator, load)

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,10 +6,11 @@
 
 mock                                # Stub out code with mock objects and make assertions about how they have been used
 ddt                                 # Run a test case multiple times with different input
-nosedjango       					# Nose testing for Django. Migration to Pytest should happen soon.
-
-# xblock-sdk==v0.1.2				# Not in use currently. To be curated.
+pytest
 # mako==1.0.2                       # Language for server-side page rendering. More tests should be added
 
 # eduNEXT mock project for couserware.model_data
--e git://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev
+-e git+https://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev
+
+# XBlock SDK to access Django Workbench Settings 
+# -e git+https://github.com/edx/xblock-sdk.git@21dac6a88fad2cf6d5588b0ee5a1e7c7d3b591fc#egg=xblock-sdk==0.1.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,34 +4,49 @@
 #
 #    make upgrade
 #
--e git+git://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev  # via -r requirements/test.in
+-e git+https://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev  # via -r requirements/test.in
 appdirs==1.4.4            # via fs
+atomicwrites==1.4.0       # via pytest
+attrs==19.3.0             # via pytest
+backports.functools-lru-cache==1.6.1  # via wcwidth
 backports.os==0.1.1       # via fs
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 ddt==1.4.1                # via -r requirements/test.in
-django==1.11.29           # via edx-opaque-keys, nosedjango
+django==1.11.29           # via edx-opaque-keys
 edx-opaque-keys[django]==2.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
 enum34==1.1.10            # via ddt, fs
 fs==2.4.11                # via xblock
+funcsigs==1.0.2           # via pytest
 future==0.18.2            # via backports.os
 futures==3.3.0            # via xblock-utils
+importlib-metadata==1.6.1  # via pluggy, pytest
 lxml==4.5.1               # via xblock
 mako==1.1.3               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
 mock==1.0.1               # via -c requirements/constraints.txt, -r requirements/test.in
-nose==1.3.7               # via nosedjango
-nosedjango==1.1.0         # via -r requirements/test.in
+more-itertools==5.0.0     # via pytest
+packaging==20.4           # via pytest
+pathlib2==2.3.5           # via importlib-metadata, pytest
 pbr==5.4.5                # via stevedore
+pluggy==0.13.1            # via pytest
+py==1.8.2                 # via pytest
 pymongo==3.10.1           # via edx-opaque-keys
+pyparsing==2.4.7          # via packaging
+pytest==4.6.11            # via -r requirements/test.in
 python-dateutil==2.8.1    # via xblock
 pytz==2020.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
-six==1.15.0               # via edx-opaque-keys, fs, python-dateutil, stevedore, xblock
+scandir==1.10.0           # via pathlib2
+six==1.15.0               # via edx-opaque-keys, fs, more-itertools, packaging, pathlib2, pytest, python-dateutil, stevedore, xblock
 stevedore==1.32.0         # via edx-opaque-keys
 typing==3.7.4.1           # via fs
+wcwidth==0.2.4            # via pytest
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock-utils==1.2.0       # via -c requirements/constraints.txt, -r requirements/base.in
 xblock==1.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, xblock-utils
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -10,11 +10,11 @@ contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtual
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+importlib-resources==2.0.1  # via virtualenv
 packaging==20.4           # via tox
 pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.8.2                 # via tox
 pyparsing==2.4.7          # via packaging
 scandir==1.10.0           # via pathlib2
 singledispatch==3.4.0.3   # via importlib-resources
@@ -22,5 +22,5 @@ six==1.15.0               # via packaging, pathlib2, tox, virtualenv
 toml==0.10.1              # via tox
 tox==3.15.2               # via -r requirements/tox.in
 typing==3.7.4.1           # via importlib-resources
-virtualenv==20.0.21       # via tox
+virtualenv==20.0.23       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,13 @@
 envlist = py27
 
 [testenv]
-deps = -r{toxinidir}/requirements/test.txt
+deps = 
+	-r {toxinidir}/requirements/test.txt
 setenv =
     DJANGO_SETTINGS_MODULE = workbench.settings
 commands =
-    nosetests -s
+    pytest
+
+[pytest]
+python_files = test_*.py
+commands = pytest


### PR DESCRIPTION
# Changed nosedjango tests to pytest-django

## Background:

We made the necessary changes so that Flow Control uses Pytest instead of Nosedjango.

## Context:

At first we tried to implement Django's TestCase module but dependencies made it way harder than it should.  The result was to keep using Python's unittest module, but without nosedjango.


## Reviewers
@morenol 

## Next steps
- Fixing tests so they use mock.courseware