### PR TITLE
Added support for Juniper testing

### DIFF
--- a/flow_control/flow.py
+++ b/flow_control/flow.py
@@ -10,7 +10,12 @@ from xblock.fragment import Fragment
 from xblock.fields import Scope, Integer, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xblock.validation import ValidationMessage
-from lms.djangoapps.courseware.model_data import ScoresClient
+
+try:
+    from lms.djangoapps.courseware.model_data import ScoresClient
+except ImportError:
+    from courseware.model_data import ScoresClient
+
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys import InvalidKeyError
 


### PR DESCRIPTION
# Added support for Juniper testing

## Background:

Juniper cleaned up plenty of dependencies (for the better!). This caused a problem in Flow Control as it now had two sources for the courseware module.

## Context:

- We added a conditional import which ensures that Flow Control imports the right courseware module, in both testing and development environments.

## Reviewers
@morenol 

## Next steps
- Formal upgrade to Python 3