### PR TITLE
Support for Python3. Dropping Python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
               only: /v?[0-9]+(\.[0-9]+)*/
           matrix:
             parameters:
-              python_version: ["2.7"]
+              python_version: ["3.5","3.8"]
       - pypi:
           requires:
             - test
@@ -24,7 +24,6 @@ jobs:
     parameters:
       python_version:
         type: string
-        default: "2.7"
     docker:
       - image: python:<< parameters.python_version >>
     working_directory: ~/flow-control-xblock
@@ -43,7 +42,7 @@ jobs:
   
   pypi:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.5
     steps:
       - checkout
       - run:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,9 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+* Support for Juniper/Python 3.5-3.8
+* Dropped support for Ironwood/Python 2.7
+
 
 [0.2.1] - 2020-06-12
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,4 +23,4 @@ Added
 _____
 
 * First release on PyPI.
-
+* Support for Ironwood/Python2.7

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,22 @@
 ==================================
-XBlock Flow Control |build-status|
+XBlock Flow Control
 ==================================
+|build-status| 
+|PyPI| 
+|PyPI license| 
 
 The Flow Control XBlock provides a way to display the content of a unit or to redirect the user elsewhere based on compliance with a condition that evaluates the submission or the score of a problem or a set of problems.
 
 Installing on Open edX Devstack
 -------------------------------
 
-Inside both LMS and Studio shells, using `make lms-shell` and `make studio-shell` in your devstack directory:
-* Clone this repository
-* Inside the newly downloaded directory, perform::
+Inside both LMS and Studio shells, using `make lms-shell` and `make studio-shell` in your devstack directory do::
 
-    make install
+    pip install flow-control-xblock
 
+However, if you want to further develop this XBlock, you might want to instead clone this repository and do::
+
+	pip install -e path/to/flow-control
 
 Enabling in Studio
 ------------------
@@ -101,3 +105,9 @@ How to Contribute
 
 .. |build-status| image:: https://circleci.com/gh/eduNEXT/flow-control-xblock.svg?style=svg
     :target: https://circleci.com/gh/eduNEXT/flow-control-xblock
+
+.. |PyPI license| image:: https://img.shields.io/pypi/l/flow-control-xblock.svg
+   :target: https://pypi.python.org/pypi/flow-control-xblock/
+
+.. |PyPI| image:: https://badge.fury.io/py/flow-control-xblock.svg
+    :target: https://badge.fury.io/py/flow-control-xblock

--- a/flow_control/flow.py
+++ b/flow_control/flow.py
@@ -229,14 +229,14 @@ class FlowCheckPointXblock(StudioEditableXBlockMixin, XBlock):
 
         if self.problem_id and self.condition == 'single_problem':
             # now split problem id by spaces or commas
-            problems = re.split('\s*,*|\s*,\s*', self.problem_id)
-            problems = filter(None, problems)
+            problems = re.findall('\w+', self.problem_id)
+            problems = list(filter(None, problems))
             problems = problems[:1]
 
         if self.list_of_problems and self.condition == 'average_problems':
             # now split list of problems id by spaces or commas
-            problems = re.split('\s*,*|\s*,\s*', self.list_of_problems)
-            problems = filter(None, problems)
+            problems = re.findall('\w+', self.list_of_problems)
+            problems = list(filter(None, problems))
 
         if problems:
             condition_reached = self.condition_on_problem_list(problems)
@@ -397,7 +397,7 @@ class FlowCheckPointXblock(StudioEditableXBlockMixin, XBlock):
         usages_keys = map(_get_usage_key, problems)
         scores_client.fetch_scores(usages_keys)
         scores = map(scores_client.get, usages_keys)
-        scores = filter(None, scores)
+        scores = list(filter(None, scores))
 
         problems_to_answer = [score.total for score in scores]
         if self.operator in self.SPECIAL_COMPARISON_DISPATCHER.keys():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,13 +5,9 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-backports.os==0.1.1       # via fs
-django==1.11.29           # via edx-opaque-keys
+django==2.2.13            # via -c requirements/constraints.txt, edx-opaque-keys
 edx-opaque-keys[django]==2.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
-enum34==1.1.10            # via fs
 fs==2.4.11                # via xblock
-future==0.18.2            # via backports.os
-futures==3.3.0            # via xblock-utils
 lxml==4.5.1               # via xblock
 mako==1.1.3               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
@@ -21,8 +17,8 @@ python-dateutil==2.8.1    # via xblock
 pytz==2020.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
 six==1.15.0               # via edx-opaque-keys, fs, python-dateutil, stevedore, xblock
-stevedore==1.32.0         # via edx-opaque-keys
-typing==3.7.4.1           # via fs
+sqlparse==0.3.1           # via django
+stevedore==1.32.0         # via -c requirements/constraints.txt, edx-opaque-keys
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock-utils==1.2.0       # via -c requirements/constraints.txt, -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,15 +8,21 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# Last Djagno version compatible with Juniper
+django<2.3
 
 # Fetches last opaque-keys version compatible with django 1.11
 edx-opaque-keys<2.1.0
 
-# Testing mock tool compatible with open-release/ironwood.master
+# Testing mock tool compatible with Juniper
 mock==1.0.1
 
-# XBlock version compatible with open-release/ironwood.master
+# stevedore 2.0.0 requires python >= 3.6
+stevedore<2.0.0
+
+# XBlock version compatible with Juniper
 xblock==1.2.2
 
-# Utilities compatible with open-release/ironwood.master
+# Utilities compatible with Juniper
 xblock-utils==1.2.0
+

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,17 +4,13 @@
 #
 #    make upgrade
 #
-astroid==1.6.6            # via pylint
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-configparser==4.0.2       # via pylint
+astroid==2.4.2            # via pylint
 coverage==5.1             # via -r requirements/quality.in
-enum34==1.1.10            # via astroid
-futures==3.3.0            # via isort
 isort==4.3.21             # via pylint
-lazy-object-proxy==1.5.0  # via astroid
+lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pep8==1.7.1               # via -r requirements/quality.in
-pylint==1.9.5             # via -r requirements/quality.in
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.15.0               # via astroid, pylint, singledispatch
+pylint==2.5.3             # via -r requirements/quality.in
+six==1.15.0               # via astroid
+toml==0.10.1              # via pylint
 wrapt==1.12.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,47 +6,34 @@
 #
 -e git+https://github.com/edunext/mock-courseware-model_data.git@30409f54e2d51b3dbdd028597e0a28bdeb9d0455#egg=dev  # via -r requirements/test.in
 appdirs==1.4.4            # via fs
-atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest
-backports.functools-lru-cache==1.6.1  # via wcwidth
-backports.os==0.1.1       # via fs
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, zipp
 ddt==1.4.1                # via -r requirements/test.in
-django==1.11.29           # via edx-opaque-keys
+django==2.2.13            # via -c requirements/constraints.txt, edx-opaque-keys
 edx-opaque-keys[django]==2.0.2  # via -c requirements/constraints.txt, -r requirements/base.in
-enum34==1.1.10            # via ddt, fs
 fs==2.4.11                # via xblock
-funcsigs==1.0.2           # via pytest
-future==0.18.2            # via backports.os
-futures==3.3.0            # via xblock-utils
-importlib-metadata==1.6.1  # via pluggy, pytest
 lxml==4.5.1               # via xblock
 mako==1.1.3               # via xblock-utils
 markupsafe==1.1.1         # via mako, xblock
 mock==1.0.1               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==5.0.0     # via pytest
+more-itertools==8.4.0     # via pytest
 packaging==20.4           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest
 pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 py==1.8.2                 # via pytest
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
-pytest==4.6.11            # via -r requirements/test.in
+pytest==5.4.3             # via -r requirements/test.in
 python-dateutil==2.8.1    # via xblock
 pytz==2020.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
-scandir==1.10.0           # via pathlib2
-six==1.15.0               # via edx-opaque-keys, fs, more-itertools, packaging, pathlib2, pytest, python-dateutil, stevedore, xblock
-stevedore==1.32.0         # via edx-opaque-keys
-typing==3.7.4.1           # via fs
+six==1.15.0               # via edx-opaque-keys, fs, packaging, python-dateutil, stevedore, xblock
+sqlparse==0.3.1           # via django
+stevedore==1.32.0         # via -c requirements/constraints.txt, edx-opaque-keys
 wcwidth==0.2.4            # via pytest
 web-fragments==0.3.2      # via xblock
 webob==1.8.6              # via xblock
 xblock-utils==1.2.0       # via -c requirements/constraints.txt, -r requirements/base.in
 xblock==1.2.2             # via -c requirements/constraints.txt, -r requirements/base.in, xblock-utils
-zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -5,22 +5,13 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata, importlib-resources, virtualenv, zipp
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==2.0.1  # via virtualenv
 packaging==20.4           # via tox
-pathlib2==2.3.5           # via importlib-metadata, importlib-resources, virtualenv
 pluggy==0.13.1            # via tox
 py==1.8.2                 # via tox
 pyparsing==2.4.7          # via packaging
-scandir==1.10.0           # via pathlib2
-singledispatch==3.4.0.3   # via importlib-resources
-six==1.15.0               # via packaging, pathlib2, tox, virtualenv
+six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox==3.15.2               # via -r requirements/tox.in
-typing==3.7.4.1           # via importlib-resources
 virtualenv==20.0.23       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ def load_requirements(*requirements_paths):
 
 with open("README.rst", "r") as file:
     long_description = file.read()
-
 setup(
     name='flow-control-xblock',
     version=__version__,
@@ -94,16 +93,18 @@ setup(
     long_description=long_description,
     long_description_content_type='text/x-rst',
     url='https://github.com/eduNEXT/flow-control-xblock',
+    python_requires=">=3.5.*",
     packages=find_packages(),
     classifiers=[
-        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet',
         'Topic :: Internet :: WWW/HTTP',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # testing with tox
 [tox]
-envlist = py27
+envlist = py35, py38
 
 [testenv]
 deps = 


### PR DESCRIPTION
# Support for Python3. Dropping Python 2.7

## Background:
We migrate from Python 2.7 to Python 3.5 and 3.8. and add support to edx-platform's Juniper release.

## Context:
- We ensured compatibility with Python3 and fixed Flow Control functions and tests.
- Changed CircleCI to test with both Python 3.5 and 3.8
- **Removed support for Python 2.7.** Developers using Ironwood should install [Flow Control 0.2.1](https://github.com/eduNEXT/flow-control-xblock/tree/v0.2.1) (also possible with pip). This is inside the changelog.
- Updated package constraints

In [Python 2.7](https://docs.python.org/2/library/functions.html#filter), the method returns a `list` and in [Python>=3.5](https://docs.python.org/3.5/library/functions.html#filter) it returns an `iterator` object.

We simply use the `list` method to transform the `iterator` and the tests pass.

_Before:_
`filter(None, problems)`

_After:_
`list(filter(None, problems))`

## Additional changes

- README now tells the user to install using pip. Added badges
- Improved a regex. Instead of splitting by commas and spaces, now we just do `re.findall('\w+', )'

## Next steps

- Upgrade this XBlock so it works with Juniper and we can soften the dependency constraints.

## Reviewers 
- @morenol 