### PR TITLE
issue: doesn't support libraries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,8 @@ Features include
 
 **WYSIWYG editor:** A simple to use HTML editor to simplify writing the content or message that learners will get if the condition is met.
 
+**Support libraries:** You can use this Xblock with library content
+
 About this XBlock
 -----------------
 


### PR DESCRIPTION
# Description

This xblock is not compatible with Libraries.

**What happens if you try to use this in a library?**

The flow control xblock expects the question id of the problem, the issue with libraries is that the problem id is dynamic based on the random problem/problems generated by a library for a given user.

**In which version of the platform have you tried this?**

Limonero master

**Do you get any particular error when trying?**

No, the flow-control xblock doesn't detect any case.

I cannot add all the problems ids for all the problem id in the library because that will work just with some cases but not for all of them.

### Note

As I cannot create issues in this repo, I just opened this PR.