### PR TITLE
feat!: dropping support for python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/x-rst',
     url='https://github.com/eduNEXT/flow-control-xblock',
-    python_requires=">=3.5.*",
+    python_requires=">=3.8",
     packages=find_packages(),
     classifiers=[
         'Framework :: Django :: 2.2',


### PR DESCRIPTION
# Description

From this point forward only python 3.8 would be supported. This was breaking installations in Palm

This came up in the forums. https://discuss.openedx.org/t/upgrading-to-tutor-16-0-3-palm/10870.
Installing this xblock in a palm release resulted in errors.

# Reviewers

- [ ]  i'll get someone to review after the test pass.

# After approval

Keep in mind that after the change have been approved we might still need to do somethings.

- [ ] Squash
- [ ] Bumpversion (major)
