### PR TITLE
docs: update readme information to indicate that some features could fail since the Open edX Olive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ However, if you want to further develop this XBlock, you might want to instead c
 
 	pip install -e path/to/flow-control
 
+⚠️ Since the Open edX Olive release, some features could fail because of the integration of [Learning MFE](https://github.com/eduNEXT/frontend-app-learning).
+
+
 Enabling in Studio
 ------------------
 


### PR DESCRIPTION
# Description

This PR contain a little update about usage information in README, to indicate that some features are deprecated since Open edX Olive.

# Reviewers

- [x] who is the person reviewing this changes? @MaferMazu 
- [ ] perhaps more than one?

# After approval

Keep in mind that after the change have been approved we might still need to do somethings.

- [ ] Squash
- [ ] Bumpversion (major/minor/patch)
