### PR TITLE
refactor: replace deprecated pkg_resources API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,17 @@ Unreleased
 
 *
 
+[2.0.1] - 2025-02-05
+**********************************************
+
+Changed
+=======
+
+* **Replaced `pkg_resources` with `importlib.resources`**  
+  - `pkg_resources` (from `setuptools`) is deprecated and may be removed in future Python versions.  
+  - Now using `importlib.resources`, the recommended alternative for managing package resources.  
+  - This improves performance and ensures better compatibility with modern Python versions.  
+
 [2.0.0] - 2025-01-23
 **********************************************
 

--- a/flow_control/__init__.py
+++ b/flow_control/__init__.py
@@ -2,4 +2,4 @@
 Init for main Flow-Control XBlock
 """
 from .flow import FlowCheckPointXblock
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/flow_control/flow.py
+++ b/flow_control/flow.py
@@ -2,7 +2,7 @@
  either display the unit's content or take an alternative action """
 
 import logging
-import pkg_resources
+from importlib.resources import files as importlib_files
 import re
 
 from functools import reduce
@@ -24,8 +24,7 @@ LOGGER = logging.getLogger(__name__)
 
 def load(path):
     """Handy helper for getting resources from our kit."""
-    data = pkg_resources.resource_string(__name__, path)
-    return data.decode("utf8")
+    return importlib_files(__package__).joinpath(path).read_text(encoding="utf-8")
 
 
 def _actions_generator(block):  # pylint: disable=unused-argument

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -89,9 +89,15 @@ class TestBuilderBlocks(unittest.TestCase):
         It should return the corresponding resource
         """
         path_mock = MagicMock()
-        with patch('importlib.resources.files') as my_patch:
-            load(path_mock)
-            my_patch.assert_called_once_with('flow_control.flow').joinpath(path_mock).read_text(encoding="utf-8")
+
+        with patch("importlib.resources.files") as mock_files:
+            mock_package = mock_files.return_value
+            mock_path = mock_package.joinpath.return_value
+            with patch.object(mock_path, "read_text") as mock_read_text:
+                load(path_mock)
+                mock_files.assert_called_once_with("flow_control.flow")
+                mock_package.joinpath.assert_called_once_with(path_mock)
+                mock_read_text.assert_called_once_with(encoding="utf-8")
 
     @ddt.data(
         'course-v1:Course+course+course',

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -95,7 +95,7 @@ class TestBuilderBlocks(unittest.TestCase):
             mock_path = mock_package.joinpath.return_value
             with patch.object(mock_path, "read_text") as mock_read_text:
                 load(path_mock)
-                mock_files.assert_called_once_with("flow_control.flow")
+                mock_files.assert_called_once_with("flow_control")
                 mock_package.joinpath.assert_called_once_with(path_mock)
                 mock_read_text.assert_called_once_with(encoding="utf-8")
 

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -88,16 +88,20 @@ class TestBuilderBlocks(unittest.TestCase):
         """
         It should return the corresponding resource
         """
-        path_mock = MagicMock()
+        path_mock = "test_resource.txt"
 
-        with patch("importlib.resources.files") as mock_files:
-            mock_package = mock_files.return_value
-            mock_path = mock_package.joinpath.return_value
-            with patch.object(mock_path, "read_text") as mock_read_text:
-                load(path_mock)
-                mock_files.assert_called_once_with(__package__)
-                mock_package.joinpath.assert_called_once_with(path_mock)
-                mock_read_text.assert_called_once_with(encoding="utf-8")
+        with patch("importlib.resources.files") as files_mock, patch("importlib.resources.as_file") as as_file_mock:
+            file_path_mock = MagicMock()
+            files_mock.return_value.joinpath.return_value = file_path_mock
+            as_file_mock.return_value.__enter__.return_value = file_path_mock
+            file_path_mock.read_text.return_value = "mocked content"
+
+            result = load(path_mock)
+
+            files_mock.assert_called_once_with("flow_control.flow")
+            file_path_mock.read_text.assert_called_once_with(encoding="utf-8")
+            assert result == "mocked content"
+
 
     @ddt.data(
         'course-v1:Course+course+course',

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -5,7 +5,7 @@ Unit tests for flow-control
 import ddt
 import unittest
 
-from mock import MagicMock, patch
+from mock import MagicMock, patch, mock_open
 # from xblock.core import XBlock
 from xblock.field_data import DictFieldData
 from flow_control.flow import FlowCheckPointXblock
@@ -85,22 +85,13 @@ class TestBuilderBlocks(unittest.TestCase):
         self.assertEqual(operators, operators_allowed)
 
     def test_load(self):
-        """
-        It should return the corresponding resource
-        """
+        """It should return the corresponding resource"""
         path_mock = "test_resource.txt"
+        mock_content = "mocked content"
 
-        with patch("importlib.resources.files") as files_mock:
-            file_path_mock = MagicMock()
-            file_path_mock.read_text.return_value = "mocked content"
-
-            files_mock.return_value.joinpath.return_value = file_path_mock
-
+        with patch("pathlib.Path.open", mock_open(read_data=mock_content)):
             result = load(path_mock)
-
-            files_mock.assert_called_once_with("flow_control.flow")
-            file_path_mock.read_text.assert_called_once_with(encoding="utf-8")
-            self.assertEqual(result, "mocked content")
+            self.assertEqual(result, mock_content)
 
     @ddt.data(
         'course-v1:Course+course+course',

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -84,15 +84,23 @@ class TestBuilderBlocks(unittest.TestCase):
         ]
         self.assertEqual(operators, operators_allowed)
 
-    def test_load():
+    def test_load(self):
         """
         It should return the corresponding resource
         """
-        path_mock = MagicMock()
-        with patch('pkg_resources.resource_string') as my_patch:
-            load(path_mock)
-            my_patch.assert_called_once_with('flow_control.flow', path_mock)
+        path_mock = "test_resource.txt"
 
+        with patch("importlib.resources.files") as files_mock:
+            file_path_mock = MagicMock()
+            file_path_mock.read_text.return_value = "mocked content"
+
+            files_mock.return_value.joinpath.return_value = file_path_mock
+
+            result = load(path_mock)
+
+            files_mock.assert_called_once_with("flow_control.flow")
+            file_path_mock.read_text.assert_called_once_with(encoding="utf-8")
+            self.assertEqual(result, "mocked content")
 
     @ddt.data(
         'course-v1:Course+course+course',

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -84,17 +84,17 @@ class TestBuilderBlocks(unittest.TestCase):
         ]
         self.assertEqual(operators, operators_allowed)
 
-    def test_load(self):
+    def test_load():
         """
         It should return the corresponding resource
         """
         path_mock = "test_resource.txt"
 
-        with patch("importlib.resources.files") as files_mock, patch("importlib.resources.as_file") as as_file_mock:
+        with patch("importlib.resources.files") as files_mock:
             file_path_mock = MagicMock()
-            files_mock.return_value.joinpath.return_value = file_path_mock
-            as_file_mock.return_value.__enter__.return_value = file_path_mock
             file_path_mock.read_text.return_value = "mocked content"
+
+            files_mock.return_value.joinpath.return_value = file_path_mock
 
             result = load(path_mock)
 

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -89,9 +89,9 @@ class TestBuilderBlocks(unittest.TestCase):
         It should return the corresponding resource
         """
         path_mock = MagicMock()
-        with patch('pkg_resources.resource_string') as my_patch:
+        with patch('importlib.resources.files') as my_patch:
             load(path_mock)
-            my_patch.assert_called_once_with('flow_control.flow', path_mock)
+            my_patch.assert_called_once_with('flow_control.flow').joinpath(path_mock).read_text(encoding="utf-8")
 
     @ddt.data(
         'course-v1:Course+course+course',

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -95,7 +95,7 @@ class TestBuilderBlocks(unittest.TestCase):
             mock_path = mock_package.joinpath.return_value
             with patch.object(mock_path, "read_text") as mock_read_text:
                 load(path_mock)
-                mock_files.assert_called_once_with("flow_control")
+                mock_files.assert_called_once_with(__package__)
                 mock_package.joinpath.assert_called_once_with(path_mock)
                 mock_read_text.assert_called_once_with(encoding="utf-8")
 

--- a/flow_control/tests/test_flowcontrol.py
+++ b/flow_control/tests/test_flowcontrol.py
@@ -88,19 +88,10 @@ class TestBuilderBlocks(unittest.TestCase):
         """
         It should return the corresponding resource
         """
-        path_mock = "test_resource.txt"
-
-        with patch("importlib.resources.files") as files_mock:
-            file_path_mock = MagicMock()
-            file_path_mock.read_text.return_value = "mocked content"
-
-            files_mock.return_value.joinpath.return_value = file_path_mock
-
-            result = load(path_mock)
-
-            files_mock.assert_called_once_with("flow_control.flow")
-            file_path_mock.read_text.assert_called_once_with(encoding="utf-8")
-            assert result == "mocked content"
+        path_mock = MagicMock()
+        with patch('pkg_resources.resource_string') as my_patch:
+            load(path_mock)
+            my_patch.assert_called_once_with('flow_control.flow', path_mock)
 
 
     @ddt.data(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = True
 tag = True
 


### PR DESCRIPTION
# Description

pkg_resources (from setuptools) is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and will be removed in future Python versions.
The new implementation uses importlib.resources, which is the recommended alternative and is fully available in Python 3.9+.

## Testing instructions

1, Create a Sumac environment using Tutor or TVM.
2. Install flow-control-xblock using this branch you can follow the official [tutor documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
3. In a course of study:
Navigate to Settings -> Advanced Settings and go to Advanced Module List settings.
Add:
![image](https://github.com/user-attachments/assets/1d2e9b87-3fba-4f11-9c82-3c61be4891e4)
4. Create  Unit -> Advance ->flow-control

# Other Information

https://github.com/openedx/public-engineering/issues/273